### PR TITLE
spring-boot-starter-web added to pom file

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,10 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter</artifactId>
         </dependency>
-
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>


### PR DESCRIPTION
spring-boot-starter-web added to pom.xml to make it possible to run the springboot project as a webapplication. More info:
https://www.javatpoint.com/spring-boot-starters
https://www.concretepage.com/questions/583